### PR TITLE
wrap cd in "" to accommodate paths with spaces

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,7 @@ set -e
 
 PROJECT_PATH="$(pwd)"
 
-cd $PROJECT_PATH/magento
+cd "$PROJECT_PATH/magento"
 
 /usr/local/bin/composer install --no-dev --no-progress
 chmod +x bin/magento


### PR DESCRIPTION
Without "" - we get a 'too many arguments' error if there happens to be a space in the path