### PR TITLE
Fix typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ For magento 2.3 & 2.4
   [See more](https://forum.madit.fr/t/magento-actions-override-default-scripts/19) about overriding
   
 
-## tipycal issues
+## Typical issues
    - To not have to constantly restart php-fpm after zero-downtime deployments please configure your http servers correctly [see here](https://forum.madit.fr/t/avoid-reloading-php-fpm-after-zero-downtime-deployments/56).
    - If you're using a self-hosted runner please run it as root user using `sudo ./svc.sh install`
    - Do not forget to set or replace the `env.php` file in the `shared` directory


### PR DESCRIPTION
Apologies for the tiny proposed change, noticed a typo in the header "typical" was spelled incorrectly.