### PR TITLE
PHP 8.2 Support for Magento 2.4.6+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,21 @@ RUN apt-get -y update \
     php8.1-xdebug \
     php8.1-soap \
     php8.1-bcmath \
+    php8.2 \
+    php8.2-common \
+    php8.2-cli \
+    php8.2-curl \
+    php8.2-dev \
+    php8.2-gd \
+    php8.2-intl \
+    php8.2-mysql \
+    php8.2-mbstring \
+    php8.2-xml \
+    php8.2-xsl \
+    php8.2-zip \
+    php8.2-xdebug \
+    php8.2-soap \
+    php8.2-bcmath \
     zip \
     default-mysql-client \
     && apt-get clean \

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Also, in some custom cases it may be needed to force/specify the php version to 
 This can be done by adding php input (after **with:** option).
 
 ##### options
-- `php:` [Optional] possible values (7.1, 7.2, 7.3, 7.4, 8.1)
+- `php:` [Optional] possible values (7.1, 7.2, 7.3, 7.4, 8.1, 8.2)
 - `composer_version:` [Optional] possible values (1, 2)
 - `process:` option [possible values](#other-processes) ('security-scan-files','static-test', 'integration-test', 'build'...)
 - see all available args in the inputs section in [actions.yml](https://github.com/MAD-I-T/magento-actions/blob/master/action.yml) 
@@ -417,7 +417,7 @@ For magento <= 2.3  ***if issues with preceding sample***
     process: 'build'
 ```
 
-- `php` : 7.1, 7.2, 7.3, 7.4 or 8.1
+- `php` : 7.1, 7.2, 7.3, 7.4, 8.1 or 8.2
 
 Use langs input to build static content for languages other than en_US or for [multi-lang support see](https://forum.madit.fr/t/build-magento-from-github-actions-static-deploy-with-multiple-languages/25/2?u=madit).
 

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Test Build Deploy M2 projects'
 author: 'MAD IT (www.madit.fr)'
 inputs: 
   php:
-    description: 'version of php to use 7.1, 7.2 or 7.4'
+    description: 'version of php to use 7.1, 7.2, 7.3, 7.4, 8.1 or 8.2'
     default: 'auto'
   process:
     description: 'Possible values: build, static-test, integration-test, unit-test, phpcs-test, deploy-staging, deploy-production, cleanup-staging, cleanup-production, security-scan-[files|modules]'

--- a/config/utils/php-compatibility-checker.sh
+++ b/config/utils/php-compatibility-checker.sh
@@ -38,8 +38,8 @@ then
     4)
       case "$minorVersion" in
         6)
-           echo "switching to php8.1 to match magento version ";
-           update-alternatives --set php /usr/bin/php8.1;
+           echo "switching to php8.2 to match magento version ";
+           update-alternatives --set php /usr/bin/php8.2;
            ;;
         4|5)
            echo "switching to php8.1 to match magento version";

--- a/scripts/create-project.sh
+++ b/scripts/create-project.sh
@@ -49,7 +49,12 @@ then
         *) echo "This version $INPUT_MAGENTO_VERSION of magento 2.4.X is not recognized minor $minorVersion" && exit 1 ;;
       esac ;;
     4)case "$minorVersion" in
-        4|5|6)
+        6)
+           php7.2 /usr/local/bin/composer self-update --2
+           update-alternatives --set php /usr/bin/php8.2
+           composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=${INPUT_MAGENTO_VERSION}
+           ;;
+        4|5)
            php7.2 /usr/local/bin/composer self-update --2
            update-alternatives --set php /usr/bin/php8.1
            composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=${INPUT_MAGENTO_VERSION}

--- a/scripts/install-mage-os.sh
+++ b/scripts/install-mage-os.sh
@@ -60,7 +60,12 @@ then
         *) echo "This version $INPUT_MAGENTO_VERSION of magento 2.4.X is not recognized minor $minorVersion" && exit 1 ;;
       esac ;;
     4)case "$minorVersion" in
-        4|5|6)
+        6)
+           php7.2 /usr/local/bin/composer self-update --2
+           update-alternatives --set php /usr/bin/php8.2
+           composer create-project --repository-url=https://mirror.mage-os.org/ magento/project-community-edition:${INPUT_MAGENTO_VERSION}
+           ;;
+        4|5)
            php7.2 /usr/local/bin/composer self-update --2
            update-alternatives --set php /usr/bin/php8.1
            composer create-project --repository-url=https://mirror.mage-os.org/ magento/project-community-edition:${INPUT_MAGENTO_VERSION}

--- a/scripts/install-magento.sh
+++ b/scripts/install-magento.sh
@@ -49,7 +49,12 @@ then
         *) echo "This version $INPUT_MAGENTO_VERSION of magento 2.4.X is not recognized minor $minorVersion" && exit 1 ;;
       esac ;;
     4)case "$minorVersion" in
-        4|5|6)
+        6)
+           php7.2 /usr/local/bin/composer self-update --2
+           update-alternatives --set php /usr/bin/php8.2
+           composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=${INPUT_MAGENTO_VERSION}
+           ;;
+        4|5)
            php7.2 /usr/local/bin/composer self-update --2
            update-alternatives --set php /usr/bin/php8.1
            composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=${INPUT_MAGENTO_VERSION}


### PR DESCRIPTION
Updated references, and documentation and included the required PHP libraries in the docker image.

Got a project I'm setting up and would prefer the build system to use the same version of PHP as the hosting environment to eliminate any issues.

Thanks!