### PR TITLE
Using npm ci instead of install to fix npm package-lock.json dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ inputs:
     default: '.'
     description: 'path to file or directory to exec, scan, etc... (phpstan)'
   node_version:
-    description: 'node version for pwa-studio'
+    description: 'node version for pwa-studio and Hyvä theme builds'
     default: 16
   version:
    description: 'generic version to be compounded with other variables e.g pwa-studio-install to specify pwa version'

--- a/config/utils/custom-theme-builder.sh
+++ b/config/utils/custom-theme-builder.sh
@@ -14,7 +14,7 @@ for file in app/design/frontend/*/*; do
       IS_NODE_SET=1
     fi
     mkdir -p "$file/web/css/"
-    npm --prefix "$file/web/tailwind" install
+    npm --prefix "$file/web/tailwind" ci
     npm --prefix "$file/web/tailwind" run build-prod
     # cleanup
     rm -rf "$file/web/tailwind/node_modules/"


### PR DESCRIPTION
Just been reading up and debugging my own issues and came across this in the Hyvä documentation (https://docs.hyva.io/hyva-themes/building-your-theme/deploying-hyva-to-production.html#1-run-npm-run-build-prod).
```
Automated builds
If you run an automated CI pipeline, use npm ci instead of npm install to install the tailwind dependencies.

The reason is that npm install might install newer package versions, while npm ci gives you a repeatable build with the exact package versions listed in package-lock.json file.
```

This would assume the version of node used to compile on the local system matches the INPUT_NODE_VERSION used by the CI system.

Kind regards,

Clive